### PR TITLE
Fix playback stopping after first song

### DIFF
--- a/SoundtrackEditorForked/EventManager.cs
+++ b/SoundtrackEditorForked/EventManager.cs
@@ -581,6 +581,9 @@ namespace SoundtrackEditor
             SoundtrackEditor.CurrentSituation.scene = Enums.ConvertScene(scenes.to);
             if (MonitorScene)
                 SoundtrackEditor.Instance.OnSituationChanged();
+
+            if (SoundtrackEditor.CurrentSituation.paused == Enums.Selector.True)
+                onGameUnpause();
         }
 
         /*private void OnGameSettingsApplied() { Utils.Log("#OnGameSettingsApplied"); }

--- a/SoundtrackEditorForked/EventManager.cs
+++ b/SoundtrackEditorForked/EventManager.cs
@@ -169,9 +169,16 @@ namespace SoundtrackEditor
                 if (IsFlightSituationChanged())
                     changed = true;
             }
-            else if (SoundtrackEditor.CurrentSituation.scene != Enums.Scenes.SpaceCentre)
+            else if (SoundtrackEditor.CurrentSituation.paused == Enums.Selector.True &&
+                SoundtrackEditor.CurrentSituation.scene != Enums.Scenes.SpaceCentre &&
+                SoundtrackEditor.CurrentSituation.scene != Enums.Scenes.Flight)
             {
-                SoundtrackEditor.CurrentSituation.paused = Enums.Selector.False;
+                // onGamePause() gets called every time the game time is stopped in the background,
+                // but we only want to treat the game as paused when the pause menu is shown.
+                // This can only be shown in SpaceCentre and in Flight, so if the CurrentSituation is
+                // set to paused in any other screen we can just call OnGameUnpaused()
+
+                onGameUnpause();
             }
 
             if (SoundtrackEditor.CurrentSituation.scene == Enums.Scenes.SpaceCentre ||


### PR DESCRIPTION
This fixes two different but related scenarios where songs play once after scene switch and then stops:

1) When in Flight mode, the game is paused and then the scene is switched to space center or tracking station scene
2) Whenever a scene where time is paused (R&D, Astronaut Complex, etc.) is entered